### PR TITLE
Recommend having `document-features` as an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Use `## ` and `#! ` comments in your Cargo.toml to document features, for exampl
 
 ```toml
 [package.metadata.docs.rs]
-all-features = true # ensures that `document-features` is enabled when building docs
+features = ["document-features"] # ensures that `document-features` is enabled when building docs
 
 [dependencies]
 document-features = { version = "0.2", optional = true }

--- a/README.md
+++ b/README.md
@@ -5,15 +5,18 @@
 
 This crate provides a macro that extracts documentation comments from Cargo.toml
 
-To use this crate, add `#![doc = document_features::document_features!()]` in your crate documentation.
+To use this crate, add `#![cfg_attr(feature = "document-features", doc = document_features::document_features!())]` in your crate documentation.
 The `document_features!()` macro reads your `Cargo.toml` file, extracts feature comments and generates
 a markdown string for your documentation.
 
 Use `## ` and `#! ` comments in your Cargo.toml to document features, for example:
 
 ```toml
+[package.metadata.docs.rs]
+all-features = true # ensures that `document-features` is enabled when building docs
+
 [dependencies]
-document-features = "0.1"
+document-features = { version = "0.2", optional = true }
 ## ...
 
 [features]

--- a/lib.rs
+++ b/lib.rs
@@ -6,7 +6,7 @@ Document your crate's feature flags.
 
 This crates provides a macro that extracts "documentation" comments from Cargo.toml
 
-To use this crate, add `#![doc = document_features::document_features!()]` in your crate documentation.
+To use this crate, add `#![cfg_attr(feature = "document-features", doc = document_features::document_features!())]` in your crate documentation.
 The `document_features!()` macro reads your `Cargo.toml` file, extracts feature comments and generates
 a markdown string for your documentation.
 
@@ -16,7 +16,7 @@ Basic example:
 //! Normal crate documentation goes here.
 //!
 //! ## Feature flags
-#![doc = document_features::document_features!()]
+#![cfg_attr(feature = "document-features", doc = document_features::document_features!())]
 
 // rest of the crate goes here.
 ```
@@ -46,7 +46,10 @@ in where they occur. Use them to group features, for example.
 #![doc = self_test!(/**
 [package]
 name = "..."
-## ...
+# ...
+
+[package.metadata.docs.rs]
+all-features = true # ensures that `document-features` is enabled when building docs
 
 [features]
 default = ["foo"]

--- a/lib.rs
+++ b/lib.rs
@@ -46,7 +46,7 @@ in where they occur. Use them to group features, for example.
 #![doc = self_test!(/**
 [package]
 name = "..."
-# ...
+## ...
 
 [package.metadata.docs.rs]
 all-features = true # ensures that `document-features` is enabled when building docs


### PR DESCRIPTION
Closes https://github.com/slint-ui/document-features/issues/7

There are two ways to successfully use `document-features`. One is to to have it as a mandatory dependency:

`document-features = "0.2"` + `#![doc = document_features::document_features!()]`

However, this adds a dependency that is only needed when building docs, which is unnecessary. The other way is to have it optional:

```toml
[package.metadata.docs.rs]
all-features = true

[dependencies]
document-features = { version = "0.2", optional = true }
```

```rs
#![cfg_attr(feature = "document-features", doc = document_features::document_features!())]
```

This is more verbose, but means the `document-features` doesn't become a build dependency, which is great.

Unfortunately, the old docs had a mix with `document-features = { version = "0.2", optional = true }` + `#![doc = document_features::document_features!()]` which fails when you do `cargo check`.

----

In this PR I suggest we always use the more verbose (but in my opinion better) way: the optional dependency.