### PR TITLE
Format features with HTML tags as `rustdoc` does

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ default = []
 
 ## Internal feature used only for the tests, don't enable
 self-test = []
+
+[dependencies]
+syn = { version = "1.0.99", default-features = false, features = ["parsing", "proc-macro"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,3 @@ default = []
 
 ## Internal feature used only for the tests, don't enable
 self-test = []
-
-[dependencies]
-syn = { version = "1.0.99", default-features = false, features = ["parsing", "proc-macro"] }

--- a/lib.rs
+++ b/lib.rs
@@ -21,6 +21,24 @@ Basic example:
 // rest of the crate goes here.
 ```
 
+In addition, you can customize the formatting of the features in the generated documentation by setting
+the key `feature_label` to a given format string. This format string must be either a string literal
+`"..."` or a raw string literal `r"..."` not delimited by number sign charaters `U+0023` (`#`) (strings like `r#"..."#`
+are not supported). Every occurrence of `{feature}` inside the format string will be substituted with the
+name of the feature.
+
+For instance, to emulate the HTML formatting used by `rustdoc` one can use the following:
+
+```rust
+#![doc = document_features::document_features!(feature_label = "<span class=\"stab portability\"><code>{feature}</code></span>")]
+```
+
+The default formatting is equivalent to:
+
+```rust
+#![doc = document_features::document_features!(feature_label = "**`{feature}`**")]
+```
+
 ## Documentation format:
 
 The documentation of your crate features goes into `Cargo.toml`, where they are defined.
@@ -100,6 +118,34 @@ The following features are experimental
 */
 )]
 /*!
+
+With the `rustdoc` styling
+
+```rust
+#![doc = document_features::document_features!(feature_label = "<span class=\"stab portability\"><code>{feature}</code></span>")]
+```
+
+the generated documentation would look like the following:
+
+<table><tr><th>Preview</th></tr><tr><td>
+This comments goes on top
+
+* <span class="stab portability"><code>foo</code></span> *(enabled by default)* —  The foo feature enables the `foo` functions
+
+* <span class="stab portability"><code>bar</code></span> —  The bar feature enables the bar module
+
+#### Experimental features
+The following features are experimental
+* <span class="stab portability"><code>fusion</code></span> —  Enable the fusion reactor
+
+  ⚠️ Can lead to explosions
+
+#### Optional dependencies
+* <span class="stab portability"><code>genial</code></span> —  Enable this feature to implement the trait for the types from the genial crate
+
+* <span class="stab portability"><code>awesome</code></span> —  This awesome dependency is specified in its own table
+</td></tr></table>
+
 
 ## Compatibility
 

--- a/lib.rs
+++ b/lib.rs
@@ -21,6 +21,8 @@ Basic example:
 // rest of the crate goes here.
 ```
 
+## Customization
+
 In addition, you can customize the formatting of the features in the generated documentation by setting
 the key `feature_label` to a given format string. This format string must be either a string literal
 `"..."` or a raw string literal `r"..."` not delimited by number sign charaters `U+0023` (`#`) (strings like `r#"..."#`

--- a/lib.rs
+++ b/lib.rs
@@ -346,8 +346,11 @@ fn process_toml(cargo_toml: &str, feature_label: Option<&str>) -> Result<String,
             if let Some(feature_label) = feature_label {
                 writeln!(
                     result,
-                    "{top}* {label}{default} —{comment}",
-                    label = feature_label.replace("{feature}", f)
+                    "{}* {}{} —{}",
+                    top,
+                    feature_label.replace("{feature}", f),
+                    default,
+                    comment
                 )
                 .unwrap();
             } else {
@@ -357,8 +360,10 @@ fn process_toml(cargo_toml: &str, feature_label: Option<&str>) -> Result<String,
             if let Some(feature_label) = feature_label {
                 writeln!(
                     result,
-                    "{top}* {label}{default}\n",
-                    label = feature_label.replace("{feature}", f)
+                    "{}* {}{}\n",
+                    top,
+                    feature_label.replace("{feature}", f),
+                    default,
                 )
                 .unwrap();
             } else {

--- a/lib.rs
+++ b/lib.rs
@@ -495,7 +495,7 @@ fn test_get_balanced() {
 #[doc(hidden)]
 /// Helper macro for the tests. Do not use
 pub fn self_test_helper(input: TokenStream) -> TokenStream {
-    process_toml((&input).to_string().trim_matches(|c| c == '"' || c == '#')).map_or_else(
+    process_toml((&input).to_string().trim_matches(|c| c == '"' || c == '#'), None).map_or_else(
         |e| error(&e),
         |r| std::iter::once(proc_macro::TokenTree::from(proc_macro::Literal::string(&r))).collect(),
     )


### PR DESCRIPTION
Hello!

With this PR I suggest formatting the features as

```html
<span class="stab portability"><code>feature</code></span>
```

instead of

```markdown
**`feature`**
```

so that they look the same as the ones automatically generated by `rustdoc`.

If you don't like this as default, I can put it behind a feature such as `html-style` or something...