### PR TITLE
Fix parsing of string literal in proc macro argument

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ default = []
 
 ## Internal feature used only for the tests, don't enable
 self-test = []
+
+[dependencies]
+litrs = "0.2.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,4 @@ default = []
 self-test = []
 
 [dependencies]
-litrs = "0.2.3"
+litrs = { version = "0.2.3", default-features = false }

--- a/tests/self-doc.rs
+++ b/tests/self-doc.rs
@@ -1,0 +1,34 @@
+#[test]
+fn ensure_it_compiles() {
+    document_features::document_features!();
+    document_features::document_features!(feature_label = "**`{feature}`**");
+    document_features::document_features!(feature_label = r"**`{feature}`**");
+    document_features::document_features!(feature_label = r#"**`{feature}`**"#);
+    document_features::document_features!(
+        feature_label = "<span class=\"stab portability\"><code>{feature}</code></span>"
+    );
+    document_features::document_features!(
+        feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#
+    );
+    document_features::document_features!(
+        feature_label = r##"<span class="stab portability"><code>{feature}</code></span>"##
+    );
+}
+
+#[test]
+fn self_doc() {
+    let actual = document_features::document_features!();
+    let expected =
+        "* **`self-test`** —  Internal feature used only for the tests, don't enable\n\n";
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn self_doc_with_custom_label() {
+    let actual = document_features::document_features!(
+        feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#
+    );
+    let expected =
+        "* <span class=\"stab portability\"><code>self-test</code></span> —  Internal feature used only for the tests, don't enable\n\n";
+    assert_eq!(actual, expected);
+}


### PR DESCRIPTION
From the commit message:

> Commit 056b0b7d09a4ed49e50182df216361397656425c removed the dependency `syn`.
>
> In doing so it introduced a bug where the string literal passed to `document_features!(feature_label = "...")` is not parsed anymore and therefore in the generated Markdown we insert a representation of the string literal as it appears in the source code instead of its content.
>
> For instance, with the call `document_features!(feature_label = r#"foo\"#)` we insert in the Markdown the text `r#"foo\"#` instead of `foo\`.